### PR TITLE
Fix hash parsing in router

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -18,7 +18,8 @@ function renderSidebar(active) {
 }
 
 function route() {
-    let hash = location.hash.replace('#', '');
+    // Normalize the hash to avoid potential issues with multiple '#'
+    let hash = location.hash.slice(1);
     let page = 'editor'; // default
     if (hash === 'browse') page = 'browse';
     if (hash === 'settings') page = 'settings';


### PR DESCRIPTION
## Summary
- improve hash parsing to use `slice(1)` for reliability

## Testing
- `node -e "console.log(require('fs').readFileSync('js/main.js','utf8'))"`

------
https://chatgpt.com/codex/tasks/task_e_68430ee1b54c8322ad3f54ee6b90eb42